### PR TITLE
feat: implement missing buffer getters & label accessors

### DIFF
--- a/cpp/WGPUInternalConstants.hpp
+++ b/cpp/WGPUInternalConstants.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include <string>
+
+namespace margelo::nitro
+{
+  static const std::string &NOT_IMPLEMENTED_LABEL_TEXT = "<not implemented yet (visible in GPU debuggers and errors)>";
+}

--- a/cpp/WGPUTypeConversions.cpp
+++ b/cpp/WGPUTypeConversions.cpp
@@ -781,4 +781,17 @@ DeviceFeature toNitroDeviceFeature(const WGPUFeatureName &featureName) {
   }
 }
 
+BufferMapState toNitroBufferMapState(const WGPUBufferMapState &state) {
+    switch (state) {
+        case WGPUBufferMapState_Mapped:
+            return BufferMapState::MAPPED;
+        case WGPUBufferMapState_Pending:
+            return BufferMapState::PENDING;
+        case WGPUBufferMapState_Unmapped:
+            return BufferMapState::UNMAPPED;
+        default:
+            return BufferMapState::UNMAPPED;
+    }
+}
+
 } // namespace margelo::nitro

--- a/cpp/WGPUTypeConversions.hpp
+++ b/cpp/WGPUTypeConversions.hpp
@@ -15,6 +15,7 @@ extern "C" {
 #include "TextureFormat.hpp"
 #include "TextureLayoutObjectSampleType.hpp"
 #include "TextureLayoutObjectViewDimension.hpp"
+#include "BufferMapState.hpp"
 
 namespace margelo::nitro {
 WGPUStorageTextureAccess
@@ -38,4 +39,5 @@ TextureDimension toNitroTextureDimension(const WGPUTextureDimension &dimension);
 TextureFormat toNitroTextureFormat(const WGPUTextureFormat &dimension);
 WGPUFeatureName toWGPUFeatureName(const DeviceFeature &feature);
 DeviceFeature toNitroDeviceFeature(const WGPUFeatureName &feature);
+BufferMapState toNitroBufferMapState(const WGPUBufferMapState &mode);
 } // namespace margelo::nitro

--- a/cpp/WebGPUBindGroup.cpp
+++ b/cpp/WebGPUBindGroup.cpp
@@ -1,4 +1,5 @@
 #include "WebGPUBindGroup.hpp"
+#include "WGPUInternalConstants.hpp"
 
 namespace margelo::nitro {
 WebGPUBindGroup::WebGPUBindGroup() : HybridObject(TAG), group_(nullptr) {}
@@ -11,4 +12,14 @@ WebGPUBindGroup::~WebGPUBindGroup() {
 }
 
 const WGPUBindGroup &WebGPUBindGroup::resource() const { return group_; }
+    std::string WebGPUBindGroup::getLabel()
+    {
+        return NOT_IMPLEMENTED_LABEL_TEXT;
+    }
+
+    void WebGPUBindGroup::setLabel(const std::string &label)
+    {
+        WGPUStringView view{label.c_str(), WGPU_STRLEN};
+        wgpuBindGroupSetLabel(group_, view);
+    }
 } // namespace margelo::nitro

--- a/cpp/WebGPUBindGroup.hpp
+++ b/cpp/WebGPUBindGroup.hpp
@@ -17,7 +17,8 @@ public:
   ~WebGPUBindGroup() override;
 
   const WGPUBindGroup &resource() const;
-
+void setLabel(const std::string &label) override;
+std::string getLabel() override;
 private:
   WGPUBindGroup group_;
 };

--- a/cpp/WebGPUBindGroupLayout.cpp
+++ b/cpp/WebGPUBindGroupLayout.cpp
@@ -1,4 +1,5 @@
 #include "WebGPUBindGroupLayout.hpp"
+#include "WGPUInternalConstants.hpp"
 
 namespace margelo::nitro {
 WebGPUBindGroupLayout::WebGPUBindGroupLayout()
@@ -13,5 +14,16 @@ WebGPUBindGroupLayout::~WebGPUBindGroupLayout() {
 
 const WGPUBindGroupLayout &WebGPUBindGroupLayout::resource() const {
   return layout_;
+}
+
+std::string WebGPUBindGroupLayout::getLabel()
+{
+    return NOT_IMPLEMENTED_LABEL_TEXT;
+}
+
+void WebGPUBindGroupLayout::setLabel(const std::string &label)
+{
+    WGPUStringView view{label.c_str(), WGPU_STRLEN};
+    wgpuBindGroupLayoutSetLabel(layout_, view);
 }
 } // namespace margelo::nitro

--- a/cpp/WebGPUBindGroupLayout.hpp
+++ b/cpp/WebGPUBindGroupLayout.hpp
@@ -16,6 +16,8 @@ public:
   ~WebGPUBindGroupLayout() override;
 
   const WGPUBindGroupLayout &resource() const;
+  void setLabel(const std::string &label) override;
+  std::string getLabel() override;
 
 private:
   WGPUBindGroupLayout layout_;

--- a/cpp/WebGPUBuffer.hpp
+++ b/cpp/WebGPUBuffer.hpp
@@ -22,6 +22,15 @@ public:
   std::shared_ptr<ArrayBuffer>
   getMappedRange(std::optional<double> offset,
                  std::optional<double> size) override;
+
+  BufferMapState getMapState() override;
+
+  double getSize() override;
+  double getUsage() override;
+
+  void setLabel(const std::string &label) override;
+  std::string getLabel() override;
+
   void unmap() override;
 
 private:

--- a/cpp/WebGPUCommandBuffer.cpp
+++ b/cpp/WebGPUCommandBuffer.cpp
@@ -1,4 +1,5 @@
 #include "WebGPUCommandBuffer.hpp"
+#include "WGPUInternalConstants.hpp"
 
 namespace margelo::nitro {
 WebGPUCommandBuffer::WebGPUCommandBuffer()
@@ -14,4 +15,12 @@ WebGPUCommandBuffer::~WebGPUCommandBuffer() {
 const WGPUCommandBuffer &WebGPUCommandBuffer::resource() const {
   return cmdBuffer_;
 }
+    void WebGPUCommandBuffer::setLabel(const std::string &label) {
+        WGPUStringView view { label.c_str(), WGPU_STRLEN };
+        wgpuCommandBufferSetLabel(cmdBuffer_, view);
+    }
+
+    std::string WebGPUCommandBuffer::getLabel() {
+        return NOT_IMPLEMENTED_LABEL_TEXT;
+    }
 } // namespace margelo::nitro

--- a/cpp/WebGPUCommandBuffer.hpp
+++ b/cpp/WebGPUCommandBuffer.hpp
@@ -17,6 +17,8 @@ public:
   ~WebGPUCommandBuffer() override;
 
   const WGPUCommandBuffer &resource() const;
+  void setLabel(const std::string &label) override;
+  std::string getLabel() override;
 
 private:
   WGPUCommandBuffer cmdBuffer_;

--- a/cpp/WebGPUCommandEncoder.cpp
+++ b/cpp/WebGPUCommandEncoder.cpp
@@ -4,6 +4,7 @@
 #include "WebGPUCommandBuffer.hpp"
 #include "WebGPUComputePassEncoder.hpp"
 #include "WebGPUTexture.hpp"
+#include "WGPUInternalConstants.hpp"
 
 namespace margelo::nitro {
 WebGPUCommandEncoder::WebGPUCommandEncoder()
@@ -312,5 +313,14 @@ void WebGPUCommandEncoder::copyTextureToBuffer(
         sizeArray.size() > 2 ? (uint32_t)sizeArray[2] : 1;
   }
 }
+
+    void WebGPUCommandEncoder::setLabel(const std::string &label) {
+        WGPUStringView view { label.c_str(), WGPU_STRLEN };
+        wgpuCommandEncoderSetLabel(commandEncoder_, view);
+    }
+
+    std::string WebGPUCommandEncoder::getLabel() {
+        return NOT_IMPLEMENTED_LABEL_TEXT;
+    }
 
 } // namespace margelo::nitro

--- a/cpp/WebGPUCommandEncoder.hpp
+++ b/cpp/WebGPUCommandEncoder.hpp
@@ -54,7 +54,8 @@ public:
       const TextureCopyDescriptor &destination,
       const std::variant<std::vector<double>, TextureCopyExtentObject>
           &copySize) override;
-
+    void setLabel(const std::string &label) override;
+    std::string getLabel() override;
 private:
   WGPUCommandEncoder commandEncoder_;
 };

--- a/cpp/WebGPUComputePassEncoder.cpp
+++ b/cpp/WebGPUComputePassEncoder.cpp
@@ -1,6 +1,7 @@
 #include "WebGPUComputePassEncoder.hpp"
 #include "WebGPUBindGroup.hpp"
 #include "WebGPUComputePipeline.hpp"
+#include "WGPUInternalConstants.hpp"
 
 namespace margelo::nitro {
 WebGPUComputePassEncoder::WebGPUComputePassEncoder()
@@ -50,5 +51,12 @@ void WebGPUComputePassEncoder::dispatchWorkgroups(double workgroupCountX,
 };
 
 void WebGPUComputePassEncoder::end() { wgpuComputePassEncoderEnd(encoder_); };
+    void WebGPUComputePassEncoder::setLabel(const std::string &label) {
+        WGPUStringView view { label.c_str(), WGPU_STRLEN };
+        wgpuComputePassEncoderSetLabel(encoder_, view);
+    }
 
+    std::string WebGPUComputePassEncoder::getLabel() {
+        return NOT_IMPLEMENTED_LABEL_TEXT;
+    }
 } // namespace margelo::nitro

--- a/cpp/WebGPUComputePassEncoder.hpp
+++ b/cpp/WebGPUComputePassEncoder.hpp
@@ -31,6 +31,8 @@ public:
   void dispatchWorkgroups(double workgroupCountX, double workgroupCountY,
                           double workgroupCountZ) override;
   void end() override;
+  void setLabel(const std::string &label) override;
+  std::string getLabel() override;
 
 private:
   WGPUComputePassEncoder encoder_;

--- a/cpp/WebGPUComputePipeline.cpp
+++ b/cpp/WebGPUComputePipeline.cpp
@@ -1,4 +1,5 @@
 #include "WebGPUComputePipeline.hpp"
+#include "WGPUInternalConstants.hpp"
 
 namespace margelo::nitro {
 WebGPUComputePipeline::WebGPUComputePipeline()
@@ -14,4 +15,14 @@ WebGPUComputePipeline::~WebGPUComputePipeline() {
 const WGPUComputePipeline &WebGPUComputePipeline::resource() const {
   return pipeline_;
 }
+
+    void WebGPUComputePipeline::setLabel(const std::string &label) {
+        WGPUStringView view { label.c_str(), WGPU_STRLEN };
+        wgpuComputePipelineSetLabel(pipeline_, view);
+    }
+
+    std::string WebGPUComputePipeline::getLabel() {
+        return NOT_IMPLEMENTED_LABEL_TEXT;
+    }
+
 } // namespace margelo::nitro

--- a/cpp/WebGPUComputePipeline.hpp
+++ b/cpp/WebGPUComputePipeline.hpp
@@ -16,6 +16,8 @@ public:
   ~WebGPUComputePipeline() override;
 
   const WGPUComputePipeline &resource() const;
+  void setLabel(const std::string &label) override;
+  std::string getLabel() override;
 
 private:
   WGPUComputePipeline pipeline_;

--- a/cpp/WebGPUDevice.cpp
+++ b/cpp/WebGPUDevice.cpp
@@ -10,6 +10,7 @@
 #include "WebGPUShaderModule.hpp"
 #include "WebGPUTexture.hpp"
 #include "WebGPUTextureView.hpp"
+#include "WGPUInternalConstants.hpp"
 
 namespace margelo::nitro {
 
@@ -512,5 +513,14 @@ RequiredLimits WebGPUDevice::getLimits() {
 DeviceInfo WebGPUDevice::getAdapterInfo() { return info_; };
 
 bool WebGPUDevice::getLost() { return false; };
+
+    void WebGPUDevice::setLabel(const std::string &label) {
+        WGPUStringView view { label.c_str(), WGPU_STRLEN };
+        wgpuDeviceSetLabel(device_, view);
+    }
+
+    std::string WebGPUDevice::getLabel() {
+        return NOT_IMPLEMENTED_LABEL_TEXT;
+    }
 
 } // namespace margelo::nitro

--- a/cpp/WebGPUDevice.hpp
+++ b/cpp/WebGPUDevice.hpp
@@ -61,6 +61,9 @@ public:
   RequiredLimits getLimits() override;
   DeviceInfo getAdapterInfo() override;
   bool getLost() override;
+  void setLabel(const std::string &label) override;
+  std::string getLabel() override;
+
 
 private:
   WGPUDevice device_;

--- a/cpp/WebGPUPipelineLayout.cpp
+++ b/cpp/WebGPUPipelineLayout.cpp
@@ -1,4 +1,5 @@
 #include "WebGPUPipelineLayout.hpp"
+#include "WGPUInternalConstants.hpp"
 
 namespace margelo::nitro {
 WebGPUPipelineLayout::WebGPUPipelineLayout()
@@ -14,4 +15,14 @@ WebGPUPipelineLayout::~WebGPUPipelineLayout() {
 const WGPUPipelineLayout &WebGPUPipelineLayout::resource() const {
   return layout_;
 }
+
+void WebGPUPipelineLayout::setLabel(const std::string &label) {
+    WGPUStringView view { label.c_str(), WGPU_STRLEN };
+    wgpuPipelineLayoutSetLabel(layout_, view);
+}
+
+std::string WebGPUPipelineLayout::getLabel() {
+    return NOT_IMPLEMENTED_LABEL_TEXT;
+}
+
 } // namespace margelo::nitro

--- a/cpp/WebGPUPipelineLayout.hpp
+++ b/cpp/WebGPUPipelineLayout.hpp
@@ -17,6 +17,8 @@ public:
   ~WebGPUPipelineLayout() override;
 
   const WGPUPipelineLayout &resource() const;
+  void setLabel(const std::string &label) override;
+  std::string getLabel() override;
 
 private:
   WGPUPipelineLayout layout_;

--- a/cpp/WebGPUQueue.cpp
+++ b/cpp/WebGPUQueue.cpp
@@ -3,6 +3,7 @@
 #include "WebGPUBuffer.hpp"
 #include "WebGPUCommandBuffer.hpp"
 #include "WebGPUTexture.hpp"
+#include "WGPUInternalConstants.hpp"
 
 namespace margelo::nitro {
 WebGPUQueue::WebGPUQueue() : HybridObject(TAG), queue_(nullptr) {}
@@ -104,5 +105,15 @@ void WebGPUQueue::writeTexture(
   wgpuQueueWriteTexture(queue_, &wgpuDestination, (void *)data->data(),
                         data->size(), &wgpuDataLayout, &wgpuExtent);
 }
+
+    void WebGPUQueue::setLabel(const std::string &label) {
+        WGPUStringView view { label.c_str(), WGPU_STRLEN };
+        wgpuQueueSetLabel(queue_, view);
+    }
+
+    std::string WebGPUQueue::getLabel() {
+        return NOT_IMPLEMENTED_LABEL_TEXT;
+    }
+
 
 } // namespace margelo::nitro

--- a/cpp/WebGPUQueue.hpp
+++ b/cpp/WebGPUQueue.hpp
@@ -33,6 +33,8 @@ public:
                     const TextureCopyDataLayout &dataLayout,
                     const std::variant<std::vector<double>,
                                        TextureCopyExtentObject> &size) override;
+  void setLabel(const std::string &label) override;
+  std::string getLabel() override;
 
 private:
   WGPUQueue queue_;

--- a/cpp/WebGPUSampler.cpp
+++ b/cpp/WebGPUSampler.cpp
@@ -1,4 +1,5 @@
 #include "WebGPUSampler.hpp"
+#include "WGPUInternalConstants.hpp"
 
 namespace margelo::nitro {
 WebGPUSampler::WebGPUSampler() : HybridObject(TAG), sampler_(nullptr) {}
@@ -11,5 +12,14 @@ WebGPUSampler::~WebGPUSampler() {
 }
 
 const WGPUSampler &WebGPUSampler::resource() const { return sampler_; }
+
+void WebGPUSampler::setLabel(const std::string &label) {
+    WGPUStringView view { label.c_str(), WGPU_STRLEN };
+    wgpuSamplerSetLabel(sampler_, view);
+}
+
+std::string WebGPUSampler::getLabel() {
+    return NOT_IMPLEMENTED_LABEL_TEXT;
+}
 
 } // namespace margelo::nitro

--- a/cpp/WebGPUSampler.hpp
+++ b/cpp/WebGPUSampler.hpp
@@ -17,6 +17,9 @@ public:
 
   const WGPUSampler &resource() const;
 
+  void setLabel(const std::string &label) override;
+  std::string getLabel() override;
+
 private:
   WGPUSampler sampler_;
 };

--- a/cpp/WebGPUShaderModule.cpp
+++ b/cpp/WebGPUShaderModule.cpp
@@ -1,4 +1,5 @@
 #include "WebGPUShaderModule.hpp"
+#include "WGPUInternalConstants.hpp"
 
 namespace margelo::nitro {
 WebGPUShaderModule::WebGPUShaderModule()
@@ -13,5 +14,14 @@ WebGPUShaderModule::~WebGPUShaderModule() {
 
 const WGPUShaderModule &WebGPUShaderModule::resource() const {
   return shaderModule_;
+}
+
+void WebGPUShaderModule::setLabel(const std::string &label) {
+    WGPUStringView view { label.c_str(), WGPU_STRLEN };
+    wgpuShaderModuleSetLabel(shaderModule_, view);
+}
+
+std::string WebGPUShaderModule::getLabel() {
+    return NOT_IMPLEMENTED_LABEL_TEXT;
 }
 } // namespace margelo::nitro

--- a/cpp/WebGPUShaderModule.hpp
+++ b/cpp/WebGPUShaderModule.hpp
@@ -17,6 +17,8 @@ public:
 
   const WGPUShaderModule &resource() const;
 
+  void setLabel(const std::string &label) override;
+  std::string getLabel() override;
 private:
   WGPUShaderModule shaderModule_;
 };

--- a/cpp/WebGPUTexture.cpp
+++ b/cpp/WebGPUTexture.cpp
@@ -1,6 +1,7 @@
 #include "WebGPUTexture.hpp"
 #include "WGPUTypeConversions.hpp"
 #include "WebGPUTextureView.hpp"
+#include "WGPUInternalConstants.hpp"
 
 namespace margelo::nitro {
 WebGPUTexture::WebGPUTexture() : HybridObject(TAG), texture_(nullptr) {}
@@ -108,6 +109,14 @@ TextureFormat WebGPUTexture::getFormat() {
 double WebGPUTexture::getUsage() {
   return (double)wgpuTextureGetUsage(texture_);
 };
+std::string WebGPUTexture::getLabel() {
+    return NOT_IMPLEMENTED_LABEL_TEXT;
+}
+
+void WebGPUTexture::setLabel(const std::string &label) {
+    WGPUStringView view { label.c_str(), WGPU_STRLEN };
+    wgpuTextureSetLabel(texture_, view);
+}
 
 const WGPUTexture &WebGPUTexture::resource() const { return texture_; }
 

--- a/cpp/WebGPUTexture.hpp
+++ b/cpp/WebGPUTexture.hpp
@@ -28,6 +28,8 @@ public:
   TextureDimension getDimension() override;
   TextureFormat getFormat() override;
   double getUsage() override;
+  void setLabel(const std::string &label) override;
+  std::string getLabel() override;
 
   const WGPUTexture &resource() const;
 

--- a/cpp/WebGPUTextureView.cpp
+++ b/cpp/WebGPUTextureView.cpp
@@ -1,4 +1,5 @@
 #include "WebGPUTextureView.hpp"
+#include "WGPUInternalConstants.hpp"
 
 namespace margelo::nitro {
 WebGPUTextureView::WebGPUTextureView()
@@ -14,5 +15,15 @@ WebGPUTextureView::~WebGPUTextureView() {
 const WGPUTextureView &WebGPUTextureView::resource() const {
   return textureView_;
 }
+
+std::string WebGPUTextureView::getLabel() {
+    return NOT_IMPLEMENTED_LABEL_TEXT;
+}
+
+void WebGPUTextureView::setLabel(const std::string &label) {
+    WGPUStringView view { label.c_str(), WGPU_STRLEN };
+    wgpuTextureViewSetLabel(textureView_, view);
+}
+
 
 } // namespace margelo::nitro

--- a/cpp/WebGPUTextureView.hpp
+++ b/cpp/WebGPUTextureView.hpp
@@ -16,6 +16,9 @@ public:
   ~WebGPUTextureView() override;
 
   const WGPUTextureView &resource() const;
+  void setLabel(const std::string &label) override;
+  std::string getLabel() override;
+
 
 private:
   WGPUTextureView textureView_;

--- a/src/WebgpuRs.nitro.ts
+++ b/src/WebgpuRs.nitro.ts
@@ -296,8 +296,15 @@ type ComputePassDescriptor = {
   // timestampWrites?: ComputePassTimestampWrite[];
 };
 
+type BufferMapState = 'unmapped' | 'pending' | 'mapped';
+
 export interface NitroWGPUBuffer
   extends HybridObject<{ ios: 'c++'; android: 'c++' }> {
+  readonly mapState: BufferMapState;
+  readonly size: number;
+  readonly usage: number;
+  label: string;
+
   mapAsync(mode: number, offset?: number, size?: number): Promise<void>;
   getMappedRange(offset?: number, size?: number): ArrayBuffer;
   unmap(): void;
@@ -340,6 +347,8 @@ export interface NitroWGPUQueue
     dataLayout: TextureCopyDataLayout,
     size: TextureCopyExtent
   ): void;
+
+  label: string;
 }
 
 type TextureCopyExtent = TextureCopyExtentObject | number[];
@@ -361,13 +370,21 @@ type BufferCopyDescriptor = {
 };
 
 export interface NitroWGPUSampler
-  extends HybridObject<{ ios: 'c++'; android: 'c++' }> {}
+  extends HybridObject<{ ios: 'c++'; android: 'c++' }> {
+  label: string;
+}
+
 export interface NitroWGPUShaderModule
-  extends HybridObject<{ ios: 'c++'; android: 'c++' }> {}
+  extends HybridObject<{ ios: 'c++'; android: 'c++' }> {
+  label: string;
+}
 export interface NitroWGPUCommandBuffer
-  extends HybridObject<{ ios: 'c++'; android: 'c++' }> {}
+  extends HybridObject<{ ios: 'c++'; android: 'c++' }> {
+  label: string;
+}
 export interface NitroWGPUCommandEncoder
   extends HybridObject<{ ios: 'c++'; android: 'c++' }> {
+  label: string;
   beginComputePass(
     descriptor: ComputePassDescriptor
   ): NitroWGPUComputePassEncoder;
@@ -423,22 +440,33 @@ export interface NitroWGPUTexture
   readonly dimension: TextureDimension;
   readonly format: TextureFormat;
   readonly usage: number;
+  label: string;
 }
 
 export interface NitroWGPUBindGroupLayout
-  extends HybridObject<{ ios: 'c++'; android: 'c++' }> {}
+  extends HybridObject<{ ios: 'c++'; android: 'c++' }> {
+  label: string;
+}
 
 export interface NitroWGPUBindGroup
-  extends HybridObject<{ ios: 'c++'; android: 'c++' }> {}
+  extends HybridObject<{ ios: 'c++'; android: 'c++' }> {
+  label: string;
+}
 
 export interface NitroWGPUTextureView
-  extends HybridObject<{ ios: 'c++'; android: 'c++' }> {}
+  extends HybridObject<{ ios: 'c++'; android: 'c++' }> {
+  label: string;
+}
 
 export interface NitroWGPUPipelineLayout
-  extends HybridObject<{ ios: 'c++'; android: 'c++' }> {}
+  extends HybridObject<{ ios: 'c++'; android: 'c++' }> {
+  label: string;
+}
 
 export interface NitroWGPUComputePipeline
-  extends HybridObject<{ ios: 'c++'; android: 'c++' }> {}
+  extends HybridObject<{ ios: 'c++'; android: 'c++' }> {
+  label: string;
+}
 
 type EncodedBindGroup = NitroWGPUBindGroup | null;
 
@@ -455,6 +483,7 @@ export interface NitroWGPUComputePassEncoder
   // popDebugGroup(): void;
   // pushDebugGroup(groupLabel: string): void;
   // insertDebugMarker(markerLabel: string): void;
+  label: string;
   end(): void;
 }
 
@@ -572,6 +601,7 @@ export interface NitroWGPUDevice
   readonly limits: RequiredLimits;
   readonly adapterInfo: DeviceInfo;
   readonly lost: boolean;
+  label: string;
 
   createBuffer(descriptor: BufferDescriptor): NitroWGPUBuffer;
   createSampler(descriptor?: SamplerDescriptor): NitroWGPUSampler;


### PR DESCRIPTION
- Added `GPUBuffer#mapState`, `GPUBuffer#usage`, `GPUBuffer#size` getters to existing object
- Added `label` accessors (both setters & getters) to all relevant resources. **Keep in mind that currently getter is not implemented correctly - it still shows fine for capturing GPU workloads and setter works as well!**